### PR TITLE
Add -y to apt-get

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 if [ ! -z $extra_packages ]  
 then
-  apt-get install $extra_packages
+  apt-get install -y $extra_packages
 fi
 
 export TEXINPUTS=.:/root/texmf//:


### PR DESCRIPTION
I think, there is a `-y` missing at `apt-get install`. When installing more dependencies, apt-get hangs with asking (doesn't it?).